### PR TITLE
107 Change name to project name

### DIFF
--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -14,6 +14,7 @@
 <div class="input-field col s12 checkbox">
   <%= f.check_box :final_confirmation, {}, "true", "false" %>
   <%= f.label :final_confirmation, "Are you able to present at the Demo Night Finals on #{@project.demo_night.final_date}?" %>
+  <p>Note: only Mod 3 and Mod 4 projects will be allowed to present at the Demo Night Finals.</p>
 </div>
 <div class="input-field col s12">
   <%= f.submit "Submit", class: "btn turing-btn" %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for @project do |f| %>
 <div class="input-field col s12">
   <%= f.text_field :name, class: "validate" %>
-  <%= f.label :name %>
+  <%= f.label "Project Name" %>
 </div>
 <div class="input-field col s12">
   <%= f.text_field :group_members, class: "validate" %>


### PR DESCRIPTION
Closes #107: @notmarkmiranda First of a few updates based on feedback from Nate. Let me know what you think.

Changes `Name` to `Project name` in the project form for create/update.