### PR TITLE
Live Scoreboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'jbuilder', '~> 2.5'
 gem "omniauth-github", '1.1.1'
 gem 'figaro'
 gem 'materialize-sass'
+gem 'redis'
 
 group :development, :test do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,7 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    redis (3.1.0)
     rspec-core (3.5.4)
       rspec-support (~> 3.5.0)
     rspec-expectations (3.5.0)
@@ -253,6 +254,7 @@ DEPENDENCIES
   puma (~> 3.0)
   rails (~> 5.0.0, >= 5.0.0.1)
   rails_12factor
+  redis
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/assets/javascripts/channels/scoreboard.coffee
+++ b/app/assets/javascripts/channels/scoreboard.coffee
@@ -1,0 +1,9 @@
+App.scoreboard = App.cable.subscriptions.create "ScoreboardChannel",
+  connected: ->
+    # Called when the subscription is ready for use on the server
+
+  disconnected: ->
+    # Called when the subscription has been terminated by the server
+
+  received: (data) ->
+    $('#main-scoreboard').replaceWith(data.message)

--- a/app/channels/scoreboard_channel.rb
+++ b/app/channels/scoreboard_channel.rb
@@ -1,0 +1,10 @@
+# Be sure to restart your server when you modify this file. Action Cable runs in a loop that does not support auto reloading.
+class ScoreboardChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "scoreboard_channel"
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+end

--- a/app/controllers/admin/scoreboard_controller.rb
+++ b/app/controllers/admin/scoreboard_controller.rb
@@ -1,0 +1,5 @@
+class Admin::ScoreboardController < Admin::BaseController
+  def show
+    @demo_night = DemoNight.current
+  end
+end

--- a/app/jobs/score_update_job.rb
+++ b/app/jobs/score_update_job.rb
@@ -1,0 +1,13 @@
+class ScoreUpdateJob < ApplicationJob
+  queue_as :default
+
+  def perform(top_five)
+    ActionCable.server.broadcast 'scoreboard_channel', message: render_projects(top_five)
+  end
+
+  private
+
+  def render_projects(projects)
+    ApplicationController.renderer.render(partial: '/admin/scoreboard/projects', locals: { projects: projects })
+  end
+end

--- a/app/models/demo_night.rb
+++ b/app/models/demo_night.rb
@@ -24,4 +24,8 @@ class DemoNight < ApplicationRecord
   def sorted_projects
     projects.sort_by { |p| p.average_total }.reverse
   end
+
+  def self.top_five
+    self.current.projects.take(5)
+  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -7,6 +7,10 @@ class Project < ApplicationRecord
 
   validates_presence_of :name
 
+  def number_of_votes
+    votes.count
+  end
+
   def average_representation
     votes.average(:representation).round(3) if votes.count != 0
   end

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -2,4 +2,6 @@ class Vote < ApplicationRecord
   belongs_to :user
   belongs_to :project
   validates :user_id, uniqueness: { scope: :project_id }
+  
+  after_create_commit { ScoreUpdateJob.perform_later DemoNight.top_five }
 end

--- a/app/views/admin/scoreboard/_projects.html.erb
+++ b/app/views/admin/scoreboard/_projects.html.erb
@@ -1,0 +1,13 @@
+<div class="top 5">
+  <% projects.each_with_index do |project, index| %>
+  <div id="name">
+    <%= index + 1 %>. Name: <b><%= project.name %></b>
+  </div>
+  <div id="number_of_votes">
+    Number of Votes: <%= project.number_of_votes %>
+  </div>
+  <div id="average_total">
+    Score: <%= project.average_total %>
+  </div>
+  <% end %>
+</div>

--- a/app/views/admin/scoreboard/_projects.html.erb
+++ b/app/views/admin/scoreboard/_projects.html.erb
@@ -1,4 +1,4 @@
-<div class="top 5">
+<div id="main-scoreboard">
   <% projects.each_with_index do |project, index| %>
   <div id="name">
     <%= index + 1 %>. Name: <b><%= project.name %></b>

--- a/app/views/admin/scoreboard/show.html.erb
+++ b/app/views/admin/scoreboard/show.html.erb
@@ -1,0 +1,15 @@
+
+<%= @demo_night.name %>
+<div id="main-scoreboard">
+  <% @demo_night.projects.each_with_index do |project, index| %>
+  <div id="name">
+    <%= index + 1 %>. Name: <b><%= project.name %></b>
+  </div>
+  <div id="number_of_votes">
+    Number of Votes: <%= project.number_of_votes %>
+  </div>
+  <div id="average_total">
+    Score: <%= project.average_total %>
+  </div>
+  <% end %>
+</div>

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,9 +1,9 @@
-production:
-  adapter: redis
-  url: redis://redistogo:6b3ef86221c09da50f1b056d3140001f@crestfish.redistogo.com:11821/
-
 development:
   adapter: async
 
 test:
   adapter: async
+
+  production:
+    adapter: redis
+    url: redis://redistogo:6b3ef86221c09da50f1b056d3140001f@crestfish.redistogo.com:11821/

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,4 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: redis://localhost:6379/1
+  url: redis://redistogo:6b3ef86221c09da50f1b056d3140001f@crestfish.redistogo.com:11821/
+  # url: redis://localhost:6379/1

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,10 +1,9 @@
+production:
+  adapter: redis
+  url: redis://redistogo:6b3ef86221c09da50f1b056d3140001f@crestfish.redistogo.com:11821/
+
 development:
   adapter: async
 
 test:
   adapter: async
-
-production:
-  adapter: redis
-  url: redis://redistogo:6b3ef86221c09da50f1b056d3140001f@crestfish.redistogo.com:11821/
-  # url: redis://localhost:6379/1

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,4 +6,5 @@ test:
 
   production:
     adapter: redis
-    url: redis://redistogo:6b3ef86221c09da50f1b056d3140001f@crestfish.redistogo.com:11821/
+    # url: redis://redistogo:6b3ef86221c09da50f1b056d3140001f@crestfish.redistogo.com:11821/
+    url: redis://redistogo:4dc8f698774c1dbd6aab249f84abeac4@viperfish.redistogo.com:10502/

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil
   config.action_cable.url = 'wss://staging-demons.herokuapp.com/cable'
-  config.action_cable.allowed_request_origins = [ 'https://staging-demons.herokuapp.com', /https:\/\/staging-demons.herokuapp.com.*/ ]
+  config.action_cable.allowed_request_origins = [ 'https://staging-demons.herokuapp.com', 'http://staging-demons.herokuapp.com' ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,8 +36,8 @@ Rails.application.configure do
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil
-  # config.action_cable.url = 'wss://example.com/cable'
-  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+  config.action_cable.url = 'wss://staging-demons.herokuapp.com/cable'
+  config.action_cable.allowed_request_origins = [ 'https://staging-demons.herokuapp.com', /https:\/\/staging-demons.herokuapp.com.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil
-  config.web_socket_server_url = 'wss://staging-demons.herokuapp.com/cable'
+  config.action_cable.url = 'wss://staging-demons.herokuapp.com/cable'
   config.action_cable.allowed_request_origins = [ 'https://staging-demons.herokuapp.com', 'http://staging-demons.herokuapp.com' ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil
-  config.action_cable.url = 'wss://staging-demons.herokuapp.com/cable'
+  config.web_socket_server_url = 'wss://staging-demons.herokuapp.com/cable'
   config.action_cable.allowed_request_origins = [ 'https://staging-demons.herokuapp.com', 'http://staging-demons.herokuapp.com' ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,8 +36,8 @@ Rails.application.configure do
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil
-  config.action_cable.url = 'wss://staging-demons.herokuapp.com/cable'
-  config.action_cable.allowed_request_origins = [ 'https://staging-demons.herokuapp.com', 'http://staging-demons.herokuapp.com' ]
+  config.action_cable.url = 'wss://demonight.herokuapp.com/cable'
+  config.action_cable.allowed_request_origins = [ 'https://demonight.herokuapp.com', 'http://demonight.herokuapp.com' ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     get '/dashboard', to: 'dashboard#show'
+    get '/scoreboard', to: 'scoreboard#show'
     resources :demo_nights, only: [:index, :show, :new, :create, :update]
     resources :projects, only: [:index, :edit, :update, :show, :destroy]
   end
@@ -20,4 +21,6 @@ Rails.application.routes.draw do
   get '/logout', to: 'sessions#destroy', as: 'logout'
   get '/login', to: 'sessions#new'
   get "/auth/:provider/callback", to: "sessions#create"
+
+  mount ActionCable.server, at: '/cable'
 end

--- a/spec/jobs/score_update_job_spec.rb
+++ b/spec/jobs/score_update_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ScoreUpdateJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# Closes #134 
## Primary
- create live scoreboard that is scoped to admin (at /admin/scoreboard)
- returns and updates top 10 scored projects on every vote

## Secondary
- add redis to queue jobs from vote model

## Misc
- I was able to test the job, but not the channels
- All tests pass: 41
- Test coverage: 79.35%

@s-espinosa 
- We need to install redistogo on heroku and get the updated directions in production.rb && cable.yml
- I set up a staging server at `https://staging-demons.herokuapp.com/`, if you log in there, I can convert you to an admin so you can watch it go. 
- @lsaville thoughts?
