### PR TITLE
Rt project notes

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -47,6 +47,6 @@ class ProjectsController < ApplicationController
   private
 
   def project_params
-    params.require(:project).permit(:group_members, :name, :project_type, :final_confirmation, :demo_night_id).merge(user_id: current_user.id)
+    params.require(:project).permit(:group_members, :name, :project_type, :final_confirmation, :demo_night_id, :note).merge(user_id: current_user.id)
   end
 end

--- a/app/views/admin/demo_nights/_vote_talley.html.erb
+++ b/app/views/admin/demo_nights/_vote_talley.html.erb
@@ -5,9 +5,9 @@
       <th>Group Members</th>
       <th>Project Type</th>
       <th>Note</th>
-      <th>Representation</th>
-      <th>Challenge</th>
-      <th>Wow</th>
+      <th>R</th>
+      <th>C</th>
+      <th>W</th>
       <th>Total Score</th>
       <th>Finals?</th>
       <th>Actions</th>
@@ -16,9 +16,9 @@
   <tbody>
     <% projects.each do |project| %>
     <tr>
-      <td class="reg"><%= project.name %></td>
-      <td class="reg"><%= project.group_members %></td>
-      <td class="reg"><%= project.project_type %></td>
+      <td class="small"><%= project.name %></td>
+      <td class="small"><%= project.group_members %></td>
+      <td class="small"><%= project.project_type %></td>
       <td class="reg"><%= project.note %></td>
       <td class="small"><%= project.average_representation %></td>
       <td class="small"><%= project.average_challenge %></td>

--- a/app/views/admin/demo_nights/_vote_talley.html.erb
+++ b/app/views/admin/demo_nights/_vote_talley.html.erb
@@ -4,6 +4,7 @@
       <th>Project Name</th>
       <th>Group Members</th>
       <th>Project Type</th>
+      <th>Note</th>
       <th>Representation</th>
       <th>Challenge</th>
       <th>Wow</th>
@@ -18,6 +19,7 @@
       <td class="reg"><%= project.name %></td>
       <td class="reg"><%= project.group_members %></td>
       <td class="reg"><%= project.project_type %></td>
+      <td class="reg"><%= project.note %></td>
       <td class="small"><%= project.average_representation %></td>
       <td class="small"><%= project.average_challenge %></td>
       <td class="small"><%= project.average_wow %></td>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -11,6 +11,10 @@
   <%= f.select(:project_type, @modules) %>
   <%= f.label :project_type %>
 </div>
+<div class="input-field col s12">
+  <%= f.text_field :note %>
+  <%= f.label :note %>
+</div>
 <div class="input-field col s12 checkbox">
   <%= f.check_box :final_confirmation, {}, "true", "false" %>
   <%= f.label :final_confirmation, "Are you able to present at the Demo Night Finals on #{@project.demo_night.final_date}?" %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -8,6 +8,7 @@
         <span class="title"><b>Project Name:</b> <%= project.name%></span>
         <p><b>Group:</b> <%= project.group_members %></p>
         <p><b>Mod:</b> <%= project.project_type %></p>
+        <p><b>Note:</b> <%= project.note %></p>
         <% if voting? %>
           <%= link_to "Rate", new_project_vote_path(project), class: "waves-effect waves-light btn turing-btn" %>
         <% end %>
@@ -27,6 +28,7 @@
         <span class="title"><b>Project Name:</b> <%= project.name%></span>
         <p><b>Group:</b> <%= project.group_members %></p>
         <p><b>Mod:</b> <%= project.project_type %></p>
+        <p><b>Note:</b> <%= project.note %></p>
         <% if voting? %>
           <%= link_to "Edit Rating", edit_project_vote_path(id: project.votes.where(user_id: current_user.id).first.id, project_id: project.id), class: "waves-effect waves-light btn turing-btn" %>
         <% end %>
@@ -43,6 +45,7 @@
         <span class="title"><b>Project Name:</b> <%= project.name%></span>
         <p><b>Group:</b> <%= project.group_members %></p>
         <p><b>Mod:</b> <%= project.project_type %></p>
+        <p><b>Note:</b> <%= project.note %></p>
       <% if owner_and_accepting(project.id) %>
         <%= link_to "Edit Project", edit_project_path(project), class: "waves-effect waves-light btn turing-btn" %>
       <% end %>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -8,7 +8,6 @@
         <span class="title"><b>Project Name:</b> <%= project.name%></span>
         <p><b>Group:</b> <%= project.group_members %></p>
         <p><b>Mod:</b> <%= project.project_type %></p>
-        <p><b>Note:</b> <%= project.note %></p>
         <% if voting? %>
           <%= link_to "Rate", new_project_vote_path(project), class: "waves-effect waves-light btn turing-btn" %>
         <% end %>
@@ -28,7 +27,6 @@
         <span class="title"><b>Project Name:</b> <%= project.name%></span>
         <p><b>Group:</b> <%= project.group_members %></p>
         <p><b>Mod:</b> <%= project.project_type %></p>
-        <p><b>Note:</b> <%= project.note %></p>
         <% if voting? %>
           <%= link_to "Edit Rating", edit_project_vote_path(id: project.votes.where(user_id: current_user.id).first.id, project_id: project.id), class: "waves-effect waves-light btn turing-btn" %>
         <% end %>
@@ -45,7 +43,6 @@
         <span class="title"><b>Project Name:</b> <%= project.name%></span>
         <p><b>Group:</b> <%= project.group_members %></p>
         <p><b>Mod:</b> <%= project.project_type %></p>
-        <p><b>Note:</b> <%= project.note %></p>
       <% if owner_and_accepting(project.id) %>
         <%= link_to "Edit Project", edit_project_path(project), class: "waves-effect waves-light btn turing-btn" %>
       <% end %>

--- a/db/migrate/20170206213539_add_note_to_project.rb
+++ b/db/migrate/20170206213539_add_note_to_project.rb
@@ -1,0 +1,5 @@
+class AddNoteToProject < ActiveRecord::Migration[5.0]
+  def change
+    add_column :projects, :note, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161230220912) do
+ActiveRecord::Schema.define(version: 20170206213539) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 20161230220912) do
     t.datetime "updated_at",         null: false
     t.integer  "demo_night_id"
     t.integer  "user_id"
+    t.text     "note"
     t.index ["demo_night_id"], name: "index_projects_on_demo_night_id", using: :btree
     t.index ["user_id"], name: "index_projects_on_user_id", using: :btree
   end

--- a/spec/features/admin/admin_can_see_project_notes_spec.rb
+++ b/spec/features/admin/admin_can_see_project_notes_spec.rb
@@ -7,7 +7,7 @@ describe 'When an admin visits the demo-night show path' do
       admin = create(:admin, uid: 123456)
       demo_night = create(:demo_night_with_projects)
       project1, project2 = demo_night.projects
-      project1.note = "make sure I win"
+      project1.update(note: "make sure I win")
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
       visit admin_demo_night_path(demo_night)

--- a/spec/features/admin/admin_can_see_project_notes_spec.rb
+++ b/spec/features/admin/admin_can_see_project_notes_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe 'When an admin visits the demo-night show path' do
+  context 'with existing projects' do
+    scenario 'they see notes for projects' do
+      user = create(:user)
+      admin = create(:admin, uid: 123456)
+      demo_night = create(:demo_night_with_projects)
+      project1, project2 = demo_night.projects
+      project1.note = "make sure I win"
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+      visit admin_demo_night_path(demo_night)
+
+      within('.projects > table > tbody') do
+        within('tr:nth-child(2)') do
+          expect(page).to have_content(project1.note)
+        end
+      end
+    end
+  end
+end

--- a/spec/features/default/user_can_create_a_project_spec.rb
+++ b/spec/features/default/user_can_create_a_project_spec.rb
@@ -9,6 +9,7 @@ describe 'When a user visits the new project path', js: true do
     visit new_project_path
     fill_in "project[group_members]", with: "Sharon Jones"
     fill_in "project[name]", with: "Witty Name"
+    fill_in "project[note]", with: "Please put me last"
     find('div.select-wrapper input').click
     find('div.select-wrapper li', text: 'BE Mod 3').click
     find('label', text: "Are you able to present at the Demo Night Finals on #{DemoNight.last.final_date}?").click
@@ -21,6 +22,7 @@ describe 'When a user visits the new project path', js: true do
     within('.unvoted') do
       expect(page).to have_content("Witty Name")
       expect(page).to have_content("Sharon Jones")
+      expect(page).to have_content("Please put me last")
       expect(page).to have_link("Edit Project", href: edit_project_path(new_project))
       expect(page).to_not have_link("Edit Project", href: edit_project_path(existing_project))
       expect(page).to_not have_link("Vote")

--- a/spec/features/default/user_can_create_a_project_spec.rb
+++ b/spec/features/default/user_can_create_a_project_spec.rb
@@ -22,7 +22,6 @@ describe 'When a user visits the new project path', js: true do
     within('.unvoted') do
       expect(page).to have_content("Witty Name")
       expect(page).to have_content("Sharon Jones")
-      expect(page).to have_content("Please put me last")
       expect(page).to have_link("Edit Project", href: edit_project_path(new_project))
       expect(page).to_not have_link("Edit Project", href: edit_project_path(existing_project))
       expect(page).to_not have_link("Vote")

--- a/spec/features/default/user_cannot_see_project_notes_spec.rb
+++ b/spec/features/default/user_cannot_see_project_notes_spec.rb
@@ -4,7 +4,7 @@ describe 'When a user visits the project index' do
   it 'they do not see notes for projects' do
     user    = create(:user)
     project = create(:project)
-    project.note = "make sure I win"
+    project.update(note: "make sure I win")
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
     visit projects_path

--- a/spec/features/default/user_cannot_see_project_notes_spec.rb
+++ b/spec/features/default/user_cannot_see_project_notes_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe 'When a user visits the project index' do
+  it 'they do not see notes for projects' do
+    user    = create(:user)
+    project = create(:project)
+    project.note = "make sure I win"
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit projects_path
+
+    expect(page).to_not have_content(project.note)
+  end
+end


### PR DESCRIPTION
@notmarkmiranda, @s-espinosa Here's a pass at adding notes to the project.

#### The user can add a note when creating a new project:
<img width="731" alt="screen shot 2017-02-14 at 1 29 27 pm" src="https://cloud.githubusercontent.com/assets/12074778/22943023/e27c29d8-f2b9-11e6-96f1-e8f58392a756.png">

#### Admins can see notes on the current projects section of their panel (demo night show page):
<img width="1177" alt="screen shot 2017-02-14 at 1 22 20 pm" src="https://cloud.githubusercontent.com/assets/12074778/22943051/07bd6900-f2ba-11e6-9ab6-320c6976a517.png">

#### No users can see the notes:
<img width="1128" alt="screen shot 2017-02-14 at 1 23 04 pm" 
src="https://cloud.githubusercontent.com/assets/12074778/22943120/517fdc6c-f2ba-11e6-8544-fa4acf1b4c18.png">

The owner can edit their note on the normal project edit form!