### PR TITLE
closes #162

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,4 @@
+class PagesController < ApplicationController
+  def clever
+  end
+end

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -3,6 +3,7 @@ class VotesController < ApplicationController
 
   def new
     @project = Project.find(params[:project_id])
+    check_eligibility(@project)
     @vote    = Vote.new
   end
 
@@ -35,6 +36,10 @@ class VotesController < ApplicationController
 
   def vote_params
     params.require(:vote).permit(:representation, :challenge, :wow)
+  end
+
+  def check_eligibility(project)
+    redirect_to clever_path if Project.ineligible.include?(project)
   end
 
   def check_voting

--- a/app/views/pages/clever.html.erb
+++ b/app/views/pages/clever.html.erb
@@ -1,0 +1,1 @@
+<h4>Sorry clever students, we fixed that hole.</h4>

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -4,7 +4,10 @@ development:
 test:
   adapter: async
 
-  production:
-    adapter: redis
-    # url: redis://redistogo:6b3ef86221c09da50f1b056d3140001f@crestfish.redistogo.com:11821/ # staging
-    url: redis://redistogo:4dc8f698774c1dbd6aab249f84abeac4@viperfish.redistogo.com:10502/ # production
+production:
+  adapter: redis
+  url: redis://redistogo:4dc8f698774c1dbd6aab249f84abeac4@viperfish.redistogo.com:10502/ # production
+
+staging:
+  adapter: redis
+  url: redis://redistogo:6b3ef86221c09da50f1b056d3140001f@crestfish.redistogo.com:11821/ # staging

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root to: 'home#show'
 
-  get '/no-demo-night', to: "home#no_demo_night"
+  get '/no-demo-night', to: 'home#no_demo_night'
 
   resources :projects, only: [:new, :create, :index, :show, :edit, :update] do
     resources :votes, only: [:new, :create, :edit, :update]
@@ -20,7 +20,8 @@ Rails.application.routes.draw do
 
   get '/logout', to: 'sessions#destroy', as: 'logout'
   get '/login', to: 'sessions#new'
-  get "/auth/:provider/callback", to: "sessions#create"
+  get '/auth/:provider/callback', to: 'sessions#create'
 
+  get '/clever_students', to: 'pages#clever', as: 'clever'
   mount ActionCable.server, at: '/cable'
 end


### PR DESCRIPTION
# Closes #162 
## Primary
- Add redirect on projects ineligible for votes (Mod 1, Mod 2, Posse Projects)
- Create new controller for `clever` error message

## Secondary
- Redefine cable.yml for staging and production.

## Tertiary
- All tests pass: 44
- Test coverage: 78.84%

## Feedback request
- @s-espinosa 
- @squeemishly
- @rongxanh88
- @JoelLindow
- @Benjaminpjacobs
