### PR TITLE
152 leave voting open past the end of demonight

### DIFF
--- a/app/views/admin/demo_nights/_demo_night.html.erb
+++ b/app/views/admin/demo_nights/_demo_night.html.erb
@@ -14,7 +14,7 @@
       <%= link_to "open voting", admin_demo_night_path(demo_night, demo_night: {status: :voting}), method: :patch, class: "waves-effect waves-light btn turing-btn" %>
       <% end %>
       <% if demo_night.status != "closed" %>
-      <%= link_to "closed", admin_demo_night_path(demo_night, demo_night: {status: :closed}), method: :patch, class: "waves-effect waves-light btn turing-btn" %>
+      <%= link_to "close", admin_demo_night_path(demo_night, demo_night: {status: :closed}), method: :patch, class: "waves-effect waves-light btn turing-btn" %>
       <% end %>
     </div>
   </div>

--- a/lib/tasks/demonight.rake
+++ b/lib/tasks/demonight.rake
@@ -1,0 +1,6 @@
+namespace :demonight do
+  desc "Nightly closes all open demonights"
+  task close: :environment do
+    DemoNight.update_all status: "closed"
+  end
+end

--- a/lib/tasks/demonight.rake
+++ b/lib/tasks/demonight.rake
@@ -1,5 +1,5 @@
 namespace :demonight do
-  desc "Nightly closes all open demonights"
+  desc "Closes all open demonights"
   task close: :environment do
     DemoNight.update_all status: "closed"
   end

--- a/spec/features/admin/admin_can_update_demo_night_status_spec.rb
+++ b/spec/features/admin/admin_can_update_demo_night_status_spec.rb
@@ -17,7 +17,7 @@ describe "When an admin views the demo night index", js: true  do
     expect(page).to have_content("#{@active.name} now voting")
     within('.active-demo-night') do
       expect(page).to_not have_link('open voting')
-      expect(page).to have_link('closed')
+      expect(page).to have_link('close')
     end
     @active.reload
     expect(@active.status).to eq("voting")

--- a/spec/features/admin/admin_cannot_activate_more_than_one_demo_night_spec.rb
+++ b/spec/features/admin/admin_cannot_activate_more_than_one_demo_night_spec.rb
@@ -22,7 +22,7 @@ describe "on updating status of demo night", js: true  do
   it "allows active demo night to be closed - from index" do
     visit admin_demo_nights_path
     within('.active-demo-night') do
-      click_link("closed")
+      click_link("close")
     end
 
     @active.reload
@@ -44,7 +44,7 @@ describe "on updating status of demo night", js: true  do
 
   it "allows active demo night to be closed - from show" do
     visit admin_demo_night_path(@active)
-    click_link("closed")
+    click_link("close")
 
     @active.reload
     expect(page).to have_content("#{@active.name} now #{@active.status.humanize.downcase}")


### PR DESCRIPTION
@s-espinosa @notmarkmiranda @rtravitz 
This:
-Adds a rake task that closes all currently open demonights.
-Fixes closed to the verb close on that button that achieves such an action.

Following the directions [here](https://devcenter.heroku.com/articles/scheduler) for someone with heroku access and setting the UTC time to 06:00 will activate this task daily at midnight. 

There is some possibility for something more advanced that triggers a background job when a demonight is created that would automatically close a demonight after a certain time increment from its inception (potentially using [delayed job](https://github.com/collectiveidea/delayed_job)) but this does the trick and should be a free add-on.