### PR TITLE
Close only demo-nights that are voting

### DIFF
--- a/lib/tasks/demonight.rake
+++ b/lib/tasks/demonight.rake
@@ -1,6 +1,6 @@
 namespace :demonight do
-  desc "Closes all open demonights"
+  desc "Closes all voting demonights"
   task close: :environment do
-    DemoNight.update_all status: "closed"
+    DemoNight.voting.update_all status: "closed"
   end
 end


### PR DESCRIPTION
@notmarkmiranda @s-espinosa @rtravitz Hey this should fix the unwarranted closure of *all* demonights and target only those who's status' are 'voting'.