### PR TITLE
Reduce number of queries

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -32,9 +32,12 @@ class Project < ApplicationRecord
   end
 
   def self.unvoted_by_user(user_id)
-    projects = Vote.where(user_id: user_id).pluck(:project_id)
     eligible = ["BE Mod 3", "FE Mod 3", "BE Mod 4", "FE Mod 4"]
-    where.not(id: projects).where(project_type: eligible)
+    where.not(
+      id: User.find(user_id)
+        .voted_projects
+        .pluck(:id)
+    ).where(project_type: eligible)
   end
 
   def self.voted_by_user(user_id)


### PR DESCRIPTION
@notmarkmiranda Can you take a look at this? Believe it reduces the number of queries run in this method.

# Summary

Believe this change reduces the number of queries used to get eligible projects without a vote from a user. Takes advantage of the `voted_projects` relationship on User.

# Details

Previously we had this:

```ruby
projects = Vote.where(user_id: user_id).pluck(:project_id)
eligible = ["BE Mod 3", "FE Mod 3", "BE Mod 4", "FE Mod 4"]
where.not(id: projects).where(project_type: eligible)
```

Which results in two queries (one when we set `projects`, and the other beginning with `where` on the third line.

Updated to the following:

```ruby
eligible = ["BE Mod 3", "FE Mod 3", "BE Mod 4", "FE Mod 4"]
where.not(
  id: User.find(user_id)
    .voted_projects
    .pluck(:id)
).where(project_type: eligible)
```

Finding the user and then finding that user's voted projects (rather than finding a value on the join given the `user_id`) seems to more directly reflect what this query is trying to do.

Thought this would still run two queries, but when I run `#to_sql` on that method it results in a single query with a subquery in it to find the voted projects. That feels like a win to me. Can you confirm?

# Questions

1. Believe we sacrifice some legibility here for fewer queries. Is it worth it?

1. I'm frustrated that the following doesn't work, and can't spot what I'm missing. Tried this with a `.find` in place of the `.where` as well:

```ruby
eligible = ["BE Mod 3", "FE Mod 3", "BE Mod 4", "FE Mod 4"]
where.not(
  User.find(user_id)
    .voted_projects
).where(project_type: eligible)
```

Might not chase this too much if the updated query in the current PR results in a single query.