### PR TITLE
Update Omniauth Github version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.2'
 gem 'jquery-rails'
 gem 'jbuilder', '~> 2.5'
-gem "omniauth-github", '1.1.1'
+gem "omniauth-github", '1.4.0'
 gem 'figaro'
 gem 'redis'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,9 +119,9 @@ GEM
     omniauth (1.9.1)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
-    omniauth-github (1.1.1)
-      omniauth (~> 1.0)
-      omniauth-oauth2 (~> 1.1)
+    omniauth-github (1.4.0)
+      omniauth (~> 1.5)
+      omniauth-oauth2 (>= 1.4.0, < 2.0)
     omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
@@ -246,7 +246,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   listen (~> 3.0.5)
-  omniauth-github (= 1.1.1)
+  omniauth-github (= 1.4.0)
   pg (~> 0.18)
   pry
   puma (~> 3.10)


### PR DESCRIPTION
Bump OmniAuth GitHub gem to see if they started sending params in the headers in accordance with GitHub's new requirement.