### PR TITLE
Add description to projects

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -17,7 +17,7 @@ class ProjectsController < ApplicationController
       flash[:success] = "Project successfully submitted!"
       redirect_to projects_path
     else
-      flash[:error] = "There was an issue creating this project"
+      flash[:error] = @project.errors.full_messages.join(". ") + "."
       redirect_to new_project_path
     end
   end
@@ -48,6 +48,6 @@ class ProjectsController < ApplicationController
   private
 
   def project_params
-    params.require(:project).permit(:group_members, :name, :project_type, :final_confirmation, :demo_night_id, :note).merge(user_id: current_user.id)
+    params.require(:project).permit(:group_members, :name, :project_type, :final_confirmation, :demo_night_id, :note, :description).merge(user_id: current_user.id)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -6,6 +6,7 @@ class Project < ApplicationRecord
   belongs_to :demo_night
 
   validates_presence_of :name
+  validates_presence_of :description
 
   def number_of_votes
     votes.count

--- a/app/views/admin/projects/_form.html.erb
+++ b/app/views/admin/projects/_form.html.erb
@@ -11,6 +11,10 @@
   <%= f.select(:project_type, @modules) %>
   <%= f.label :project_type %>
 </div>
+<div class="input-field col s12">
+  <%= f.text_field :description %>
+  <%= f.label :description %>
+</div>
 <div class="input-field col s12 checkbox">
   <%= f.check_box :final_confirmation, {}, "true", "false" %>
   <%= f.label :final_confirmation, 'Are you able to present at the Demo Night Finals?' %>

--- a/app/views/projects/_form.html.erb
+++ b/app/views/projects/_form.html.erb
@@ -12,8 +12,8 @@
   <%= f.label :project_type %>
 </div>
 <div class="input-field col s12">
-  <%= f.text_field :note %>
-  <%= f.label :note %>
+  <%= f.text_field :description %>
+  <%= f.label :description %>
 </div>
 <div class="col s12 checkbox">
   <%= f.check_box :final_confirmation, {}, "true", "false" %>

--- a/db/migrate/20210129072024_add_description_to_projects.rb
+++ b/db/migrate/20210129072024_add_description_to_projects.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToProjects < ActiveRecord::Migration[5.1]
+  def change
+    add_column :projects, :description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,57 +10,58 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190720234753) do
+ActiveRecord::Schema.define(version: 20210129072024) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "demo_nights", force: :cascade do |t|
-    t.string  "name"
-    t.integer "status",     default: 0
-    t.date    "final_date"
+  create_table "demo_nights", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.integer "status", default: 0
+    t.date "final_date"
   end
 
-  create_table "projects", force: :cascade do |t|
-    t.string   "group_members"
-    t.string   "name"
-    t.string   "project_type"
-    t.boolean  "final_confirmation"
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
-    t.integer  "demo_night_id"
-    t.integer  "user_id"
-    t.text     "note"
-    t.float    "archived_average_representation"
-    t.float    "archived_average_challenge"
-    t.float    "archived_average_wow"
-    t.float    "archived_average_total"
-    t.index ["demo_night_id"], name: "index_projects_on_demo_night_id", using: :btree
-    t.index ["user_id"], name: "index_projects_on_user_id", using: :btree
+  create_table "projects", id: :serial, force: :cascade do |t|
+    t.string "group_members"
+    t.string "name"
+    t.string "project_type"
+    t.boolean "final_confirmation"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "demo_night_id"
+    t.integer "user_id"
+    t.text "note"
+    t.float "archived_average_representation"
+    t.float "archived_average_challenge"
+    t.float "archived_average_wow"
+    t.float "archived_average_total"
+    t.string "description"
+    t.index ["demo_night_id"], name: "index_projects_on_demo_night_id"
+    t.index ["user_id"], name: "index_projects_on_user_id"
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string   "provider"
-    t.string   "uid"
-    t.string   "name"
-    t.string   "email"
-    t.string   "nickname"
-    t.string   "github"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.integer  "role",       default: 0
+  create_table "users", id: :serial, force: :cascade do |t|
+    t.string "provider"
+    t.string "uid"
+    t.string "name"
+    t.string "email"
+    t.string "nickname"
+    t.string "github"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "role", default: 0
   end
 
-  create_table "votes", force: :cascade do |t|
-    t.integer  "user_id"
-    t.integer  "project_id"
-    t.integer  "representation"
-    t.integer  "challenge"
-    t.integer  "wow"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
-    t.index ["project_id"], name: "index_votes_on_project_id", using: :btree
-    t.index ["user_id"], name: "index_votes_on_user_id", using: :btree
+  create_table "votes", id: :serial, force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "project_id"
+    t.integer "representation"
+    t.integer "challenge"
+    t.integer "wow"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id"], name: "index_votes_on_project_id"
+    t.index ["user_id"], name: "index_votes_on_user_id"
   end
 
   add_foreign_key "projects", "demo_nights"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -19,6 +19,7 @@ FactoryBot.define do
     sequence :name do |n|
       "Witty Name #{n}"
     end
+    description { "A great project!" }
     project_type { "BE Mod 3" }
     final_confirmation { true }
     demo_night

--- a/spec/features/default/user_can_create_a_project_spec.rb
+++ b/spec/features/default/user_can_create_a_project_spec.rb
@@ -9,7 +9,7 @@ describe 'When a user visits the new project path', js: true do
     visit new_project_path
     fill_in "project[group_members]", with: "Sharon Jones"
     fill_in "project[name]", with: "Witty Name"
-    fill_in "project[note]", with: "Please put me last"
+    fill_in "project[description]", with: "A great project."
     find('div.select-wrapper input').click
     find('div.select-wrapper li', text: 'BE Mod 3').click
     find('label', text: "Are you able to present at the Demo Night Finals on #{DemoNight.last.final_date}?").click
@@ -26,5 +26,21 @@ describe 'When a user visits the new project path', js: true do
       expect(page).to_not have_link("Edit Project", href: edit_project_path(existing_project))
       expect(page).to_not have_link("Vote")
     end
+  end
+
+  it "they cannot create a new project without a description" do
+    create(:demo_night_with_projects)
+    user = create(:user)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit new_project_path
+    fill_in "project[group_members]", with: "Sharon Jones"
+    fill_in "project[name]", with: "Witty Name"
+    find('div.select-wrapper input').click
+    find('div.select-wrapper li', text: 'BE Mod 3').click
+    find('label', text: "Are you able to present at the Demo Night Finals on #{DemoNight.last.final_date}?").click
+    click_on "Submit"
+
+    expect(page).to have_content("Description can't be blank.")
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -6,4 +6,5 @@ describe Project do
   it { should belong_to(:demo_night) }
   it { should belong_to(:owner) }
   it { should validate_presence_of :name }
+  it { should validate_presence_of :description }
 end


### PR DESCRIPTION
# Background

* Emma has had to collect project descriptions over Slack. It would be easier if this was just required when projects were submitted.
* We have not been using the notes column since demo night is no longer a part of graduation.

# PR Description

* Add description to projects table.
* Add description to new project form for a default user.
* Remove note from new project form for a default user.
* Add description to admin user form to edit a project.
* Add validation for description to Project model.
* Update error message that displays to more clearly indicate that a description is required.
* Update project creation spec.
* Add feature spec to confirm description validation.
* Add model spec to confirm description validation.
* Update spec project factory to include description.