### PR TITLE
Add description to DemoNight show page

### DIFF
--- a/app/views/admin/demo_nights/_vote_talley.html.erb
+++ b/app/views/admin/demo_nights/_vote_talley.html.erb
@@ -4,7 +4,7 @@
       <th>Project Name</th>
       <th>Group Members</th>
       <th>Project Type</th>
-      <th>Note</th>
+      <th>Description</th>
       <th>R</th>
       <th>C</th>
       <th>W</th>
@@ -19,7 +19,7 @@
       <td class="small"><%= project.name %></td>
       <td class="small"><%= project.group_members %></td>
       <td class="small"><%= project.project_type %></td>
-      <td class="reg"><%= project.note %></td>
+      <td class="reg"><%= project.description %></td>
       <td class="small"><%= project.average_representation %></td>
       <td class="small"><%= project.average_challenge %></td>
       <td class="small"><%= project.average_wow %></td>


### PR DESCRIPTION
Make it so that the new Description column in the DB is displayed in the show page for the Demo Night.